### PR TITLE
Naive Listening Analysis

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,11 +8,25 @@ datasource db {
 }
 
 model User {
-  id           String   @id
-  createdAt    DateTime @default(now())
+  id           String    @id
+  createdAt    DateTime  @default(now())
   accessToken  String
   refreshToken String
   name         String
   uri          String
   image        String?
+  interests    Interest?
+}
+
+model Interest {
+  id     Int    @id @default(autoincrement())
+  user   User   @relation(fields: userId, references: [id])
+  userId String @unique
+
+  energy       Float
+  valence      Float
+  liveness     Float
+  loudness     Float
+  acousticness Float
+  danceability Float
 }

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,9 +1,7 @@
-import type { User } from '@prisma/client';
-
 declare global {
 	namespace App {
 		interface Locals {
-			user: User | null;
+			user: App.DB.UserWithRelations | null;
 		}
 	}
 	interface ImportMetaEnv {

--- a/src/lib/constants/spotify.ts
+++ b/src/lib/constants/spotify.ts
@@ -5,8 +5,10 @@
 export const PROFILE_URL = 'https://api.spotify.com/v1/me';
 export const AUTH_URL = 'https://accounts.spotify.com/authorize';
 export const TOKEN_URL = 'https://accounts.spotify.com/api/token';
+export const TOP_TRACKS_URL = 'https://api.spotify.com/v1/me/top/tracks';
+export const AUDIO_FEATURES_URL = 'https://api.spotify.com/v1/audio-features';
 
 /**
  * Data Configs
  */
-export const SCOPES = ['user-top-read', 'user-read-currently-playing'];
+export const SCOPES = ['user-top-read'];

--- a/src/lib/server/api/helpers.server.ts
+++ b/src/lib/server/api/helpers.server.ts
@@ -1,7 +1,15 @@
 export async function fetchJSON<T extends { [key: string]: any }>(
-	...params: Parameters<typeof fetch>
+	accessToken: string | null,
+	url: string,
+	rest?: Parameters<typeof fetch>[1]
 ): Promise<T> {
-	const response = await fetch(...params);
+	const response = await fetch(url, {
+		...rest,
+		headers: {
+			...rest?.headers,
+			Authorization: accessToken ? `Bearer ${accessToken}` : '',
+		},
+	});
 	const responseJSON = (await response.json()) as T;
 	return responseJSON;
 }

--- a/src/lib/server/api/helpers.server.ts
+++ b/src/lib/server/api/helpers.server.ts
@@ -1,0 +1,7 @@
+export async function fetchJSON<T extends { [key: string]: any }>(
+	...params: Parameters<typeof fetch>
+): Promise<T> {
+	const response = await fetch(...params);
+	const responseJSON = (await response.json()) as T;
+	return responseJSON;
+}

--- a/src/lib/server/api/spotify.server.ts
+++ b/src/lib/server/api/spotify.server.ts
@@ -1,26 +1,30 @@
 import { TOKEN_URL } from '$lib/constants/spotify';
 
+import * as APIHelpers from './helpers.server';
+
 export const SpotifyAPI = {
 	getTokens,
 	getProfileData,
 };
 
 async function getTokens(code: string): Promise<API.Spotify.TokenData> {
-	const response = await fetch(TOKEN_URL, {
-		method: 'POST',
-		headers: {
-			'Content-Type': 'application/x-www-form-urlencoded',
-		},
-		body: new URLSearchParams({
-			code,
-			grant_type: 'authorization_code',
-			client_id: import.meta.env.VITE_SPOTIFY_CLIENT_ID,
-			redirect_uri: import.meta.env.VITE_SPOTIFY_REDIRECT_URI,
-			client_secret: import.meta.env.VITE_SPOTIFY_CLIENT_SECRET,
-		}),
-	});
+	const data = await APIHelpers.fetchJSON<API.Spotify.TokenResponse>(
+		TOKEN_URL,
+		{
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams({
+				code,
+				grant_type: 'authorization_code',
+				client_id: import.meta.env.VITE_SPOTIFY_CLIENT_ID,
+				redirect_uri: import.meta.env.VITE_SPOTIFY_REDIRECT_URI,
+				client_secret: import.meta.env.VITE_SPOTIFY_CLIENT_SECRET,
+			}),
+		}
+	);
 
-	const data = await response.json();
 	return {
 		access: data.access_token,
 		refresh: data.refresh_token,
@@ -30,17 +34,19 @@ async function getTokens(code: string): Promise<API.Spotify.TokenData> {
 async function getProfileData(
 	accessToken: string
 ): Promise<App.Spotify.Profile> {
-	const profileResponse = await fetch('https://api.spotify.com/v1/me', {
-		headers: {
-			Authorization: `Bearer ${accessToken}`,
-		},
-	});
+	const profileData = await APIHelpers.fetchJSON<API.Spotify.ProfileData>(
+		'https://api.spotify.com/v1/me',
+		{
+			headers: {
+				Authorization: `Bearer ${accessToken}`,
+			},
+		}
+	);
 
-	const profileData = (await profileResponse.json()) as API.Spotify.ProfileData;
 	return {
 		id: profileData.id,
 		uri: profileData.uri,
 		name: profileData.display_name,
 		image: profileData.images?.[0]?.url || null,
-	} as App.Spotify.Profile;
+	};
 }

--- a/src/lib/server/api/spotify.server.ts
+++ b/src/lib/server/api/spotify.server.ts
@@ -1,8 +1,8 @@
 import {
-	AUDIO_FEATURES_URL,
-	PROFILE_URL,
 	TOKEN_URL,
+	PROFILE_URL,
 	TOP_TRACKS_URL,
+	AUDIO_FEATURES_URL,
 } from '$lib/constants/spotify';
 
 import * as APIHelpers from './helpers.server';
@@ -15,6 +15,7 @@ export const SpotifyAPI = {
 
 async function getTokens(code: string): Promise<API.Spotify.TokenData> {
 	const data = await APIHelpers.fetchJSON<API.Spotify.TokenResponse>(
+		null,
 		TOKEN_URL,
 		{
 			method: 'POST',
@@ -41,12 +42,8 @@ async function getProfileData(
 	accessToken: string
 ): Promise<App.Spotify.Profile> {
 	const profileData = await APIHelpers.fetchJSON<API.Spotify.ProfileData>(
-		PROFILE_URL,
-		{
-			headers: {
-				Authorization: `Bearer ${accessToken}`,
-			},
-		}
+		accessToken,
+		PROFILE_URL
 	);
 
 	return {
@@ -67,12 +64,8 @@ async function getTrackFeatures(
 
 	const audioFeatures =
 		await APIHelpers.fetchJSON<API.Spotify.AudioFeaturesData>(
-			`${AUDIO_FEATURES_URL}?${searchParams}`,
-			{
-				headers: {
-					Authorization: `Bearer ${accessToken}`,
-				},
-			}
+			accessToken,
+			`${AUDIO_FEATURES_URL}?${searchParams}`
 		);
 
 	// Filtering out unused API Response fields
@@ -100,12 +93,8 @@ async function getTopTracks(
 	});
 
 	const topTracksData = await APIHelpers.fetchJSON<API.Spotify.TopTracksData>(
-		`${TOP_TRACKS_URL}?${searchParams}`,
-		{
-			headers: {
-				Authorization: `Bearer ${accessToken}`,
-			},
-		}
+		accessToken,
+		`${TOP_TRACKS_URL}?${searchParams}`
 	);
 
 	return topTracksData.items.map((item) => item.id);

--- a/src/lib/server/db/interests.server.ts
+++ b/src/lib/server/db/interests.server.ts
@@ -3,12 +3,12 @@ import { PrismaClient, type Interest, type User } from '@prisma/client';
 const db = new PrismaClient();
 
 export const InterestsModel = {
-	buildInterests,
-	createInterests,
-	updateInterests,
+	create,
+	update,
+	mergeByAverage,
 };
 
-function buildInterests(
+function mergeByAverage(
 	interests: API.Spotify.AudioFeatureData[]
 ): API.Spotify.AudioFeatureData {
 	const avgObj: Partial<API.Spotify.AudioFeatureData> = {};
@@ -24,7 +24,7 @@ function buildInterests(
 	return avgObj as API.Spotify.AudioFeatureData;
 }
 
-async function createInterests(
+async function create(
 	user: User,
 	interests: API.Spotify.AudioFeatureData
 ): Promise<void> {
@@ -36,7 +36,7 @@ async function createInterests(
 	});
 }
 
-async function updateInterests(
+async function update(
 	previousInterests: Interest,
 	currentInterests: API.Spotify.AudioFeatureData
 ): Promise<void> {

--- a/src/lib/server/db/interests.server.ts
+++ b/src/lib/server/db/interests.server.ts
@@ -1,0 +1,61 @@
+import { PrismaClient, type Interest, type User } from '@prisma/client';
+
+const db = new PrismaClient();
+
+export const InterestsModel = {
+	buildInterests,
+	createInterests,
+	updateInterests,
+};
+
+function buildInterests(
+	interests: API.Spotify.AudioFeatureData[]
+): API.Spotify.AudioFeatureData {
+	const avgObj: Partial<API.Spotify.AudioFeatureData> = {};
+	const keys = Object.keys(interests[0]) as Array<
+		keyof API.Spotify.AudioFeatureData
+	>;
+
+	for (const key of keys) {
+		const sum = interests.reduce((prev, curr) => prev + curr[key], 0);
+		avgObj[key] = sum / interests.length;
+	}
+
+	return avgObj as API.Spotify.AudioFeatureData;
+}
+
+async function createInterests(
+	user: User,
+	interests: API.Spotify.AudioFeatureData
+): Promise<void> {
+	db.interest.create({
+		data: {
+			...interests,
+			userId: user.id,
+		},
+	});
+}
+
+async function updateInterests(
+	previousInterests: Interest,
+	currentInterests: API.Spotify.AudioFeatureData
+): Promise<void> {
+	const keys = Object.keys(currentInterests) as Array<
+		keyof API.Spotify.AudioFeatureData
+	>;
+
+	const newInterests = keys.reduce(
+		(prev, key) => ({
+			...prev,
+			[key]: (previousInterests[key] + currentInterests[key]) / 2,
+		}),
+		{} as Partial<Interest>
+	);
+
+	db.interest.update({
+		where: {
+			id: previousInterests.id,
+		},
+		data: newInterests,
+	});
+}

--- a/src/routes/api/auth/login/+server.ts
+++ b/src/routes/api/auth/login/+server.ts
@@ -1,9 +1,9 @@
 import { json } from '@sveltejs/kit';
 import { UserModel } from '$lib/server/db/user.server';
 import { SpotifyAPI } from '$lib/server/api/spotify.server';
+import { InterestsModel } from '$lib/server/db/interests.server';
 
 import type { RequestHandler } from '../$types';
-import { InterestsModel } from '$lib/server/db/interests.server';
 
 /**
  * handles `POST /api/auth/login`
@@ -16,7 +16,6 @@ export const POST = (async ({ request, cookies }) => {
 	const interests = InterestsModel.buildInterests(featureSet);
 
 	let user = await UserModel.getByIdAndUpdate(profile.id, tokenData);
-
 	if (user) {
 		if (user.interests) {
 			await InterestsModel.updateInterests(user.interests, interests);

--- a/src/routes/api/auth/login/+server.ts
+++ b/src/routes/api/auth/login/+server.ts
@@ -13,14 +13,14 @@ export const POST = (async ({ request, cookies }) => {
 	const tokenData = await SpotifyAPI.getTokens(code);
 	const profile = await SpotifyAPI.getProfileData(tokenData.access);
 	const featureSet = await SpotifyAPI.getTrackFeatures(tokenData.access);
-	const interests = InterestsModel.buildInterests(featureSet);
+	const interests = InterestsModel.mergeByAverage(featureSet);
 
 	let user = await UserModel.getByIdAndUpdate(profile.id, tokenData);
 	if (user) {
 		if (user.interests) {
-			await InterestsModel.updateInterests(user.interests, interests);
+			await InterestsModel.update(user.interests, interests);
 		} else {
-			await InterestsModel.createInterests(user, interests);
+			await InterestsModel.create(user, interests);
 		}
 	} else {
 		user = await UserModel.create(profile, tokenData, interests);

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -2,9 +2,20 @@
 	import type { LayoutData } from './$types';
 
 	export let data: LayoutData;
+	const interests = data.user.interests;
+	const keys =
+		interests && (Object.keys(interests) as Array<keyof typeof interests>);
 </script>
 
 <div class="w-full h-full flex flex-col items-center justify-center">
-	<h1>Hello {data.user.name}</h1>
-	<p>id: <i>{data.user.id}</i></p>
+	<div class="mockup-code">
+		<pre data-prefix="$" class="bg-warning text-warning-content"><code
+				>name -> {data.user.name}</code
+			></pre>
+		{#if keys}
+			{#each keys as key}
+				<pre data-prefix=">"><code>{key} -> {interests[key]}</code></pre>
+			{/each}
+		{/if}
+	</div>
 </div>

--- a/src/types/api/spotify.d.ts
+++ b/src/types/api/spotify.d.ts
@@ -38,6 +38,32 @@ declare global {
 				followers: FollowerData;
 				external_urls: ExternalURLs;
 			}
+
+			interface TrackItemData {
+				id: string;
+			}
+
+			interface TopTracksData {
+				total: number;
+				limit: number;
+				offset: number;
+				prev: string | null;
+				next: string | null;
+				items: TrackItemData[];
+			}
+
+			interface AudioFeatureData {
+				energy: number;
+				valence: number;
+				liveness: number;
+				loudness: number;
+				acousticness: number;
+				danceability: number;
+			}
+
+			interface AudioFeaturesData {
+				audio_features: AudioFeatureData[];
+			}
 		}
 	}
 }

--- a/src/types/api/spotify.d.ts
+++ b/src/types/api/spotify.d.ts
@@ -18,6 +18,11 @@ declare global {
 				height: number | null;
 			};
 
+			interface TokenResponse {
+				access_token: string;
+				refresh_token: string;
+			}
+
 			interface TokenData {
 				access: string;
 				refresh: string;

--- a/src/types/app/db.d.ts
+++ b/src/types/app/db.d.ts
@@ -9,4 +9,5 @@ declare global {
 		}
 	}
 }
+
 export {};

--- a/src/types/app/db.d.ts
+++ b/src/types/app/db.d.ts
@@ -1,0 +1,12 @@
+import type { Interest, User } from '@prisma/client';
+
+declare global {
+	namespace App {
+		namespace DB {
+			type UserWithRelations = User & {
+				interests: Interest | null;
+			};
+		}
+	}
+}
+export {};


### PR DESCRIPTION
# Proposed Changes

- [x] Add a new `Interest` DB Model.
- [x] Build User Interest on login
	On first login:
	- [x] Fetch user's top tracks
	- [x] Fetch the featureset of these tracks
	- [x] Isolate interests from the featureset
	- [x] Caluclate the average of these interests
	- [x] Create an `Interest` instance and attach it to the user
	
	On consequent logins:
	- [x] Find users current interests
	- [x] Update user's existing interests with the current ones